### PR TITLE
Adding support for targeting .NET 6

### DIFF
--- a/CodeMirror6/CodeMirror6.csproj
+++ b/CodeMirror6/CodeMirror6.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -20,7 +20,7 @@
     <Title>GaelJ.BlazorCodeMirror6</Title>
     <Description>
       Blazor CodeMirror 6 brings the power of the [CodeMirror 6](https://codemirror.net/)
-      code editor to Blazor, offering a comprehensive .NET 7 / .NET 8 component.
+      code editor to Blazor, offering a comprehensive .NET 6 / .NET 7 / .NET 8 component.
       It's tailored for both general and specialized use-cases, supporting a range of
       languages and Markdown editing, extensive support for syntax highlighting,
       auto-completion, custom linting, themes, Markdown preview, and more.
@@ -38,6 +38,7 @@
     <SupportedPlatform Include="browser-wasm" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.25" Condition="'$(TargetFramework)'=='net6.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" Condition="'$(TargetFramework)'=='net7.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" Condition="'$(TargetFramework)'=='net8.0'" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![codemirror.svg](codemirror.svg)
 
-Blazor CodeMirror 6 brings the power of the [CodeMirror 6](https://codemirror.net/) code editor to Blazor, offering a comprehensive .NET 7 / .NET 8 component. It's tailored for both general and specialized use-cases, supporting a range of languages and Markdown editing, extensive support for syntax highlighting, auto-completion, custom linting, themes, Markdown preview, and more.
+Blazor CodeMirror 6 brings the power of the [CodeMirror 6](https://codemirror.net/) code editor to Blazor, offering a comprehensive .NET 6 / .NET 7 / .NET 8 component. It's tailored for both general and specialized use-cases, supporting a range of languages and Markdown editing, extensive support for syntax highlighting, auto-completion, custom linting, themes, Markdown preview, and more.
 
 ## Try It Out
 


### PR DESCRIPTION
## What's this change all about?

This is support for targeting .NET 6

## What's changed?

- csproj file now targets .NET 6, including a .NET 6 compliant reference to `Microsoft.AspNetCore.Components.Web`
- update to README