### PR TITLE
More language data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.2.1 - 2024-01-31
+
+### ✨ Introduce new features
+
+- Add DisplayName() extension to CodeMirrorLanguage enum
+- Allow scrolling past the end of the document
+- Implement white space & trailing white space highlighting
+
+### 🐛 Fix a bug
+
+- Fix dragging text was highjacked by the file drag overlay
+- Fix empty language definitions in example
+
+### ✏️ Fix typos
+
+- Display Plain Text language name with space
+
 ## 0.2.0 - 2024-01-31
 
 ### ✨ Introduce new features

--- a/CodeMirror6/CodeMirror6.csproj
+++ b/CodeMirror6/CodeMirror6.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>GaelJ.BlazorCodeMirror6</AssemblyName>
     <IsPackable>true</IsPackable>
     <PackageId>GaelJ.BlazorCodeMirror6</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/CodeMirror6/CodeMirror6Wrapper.razor
+++ b/CodeMirror6/CodeMirror6Wrapper.razor
@@ -32,6 +32,8 @@
             UploadFile="@UploadFile"
             MergeViewConfiguration="@MergeViewConfiguration"
             FileNameOrExtension="@FileNameOrExtension"
+            HighlightWhitespace="@HighlightWhitespace"
+            HighlightTrailingWhitespace="@HighlightTrailingWhitespace"
         />
     </ChildContent>
     <ErrorContent Context="c">

--- a/CodeMirror6/CodeMirror6Wrapper.razor.cs
+++ b/CodeMirror6/CodeMirror6Wrapper.razor.cs
@@ -155,6 +155,16 @@ public partial class CodeMirror6Wrapper : ComponentBase
     /// <value></value>
     [Parameter] public UnifiedMergeConfig? MergeViewConfiguration { get; set; }
     /// <summary>
+    /// Whether to allow horizontal resizing similar to a textarea
+    /// </summary>
+    /// <value></value>
+    [Parameter] public bool HighlightTrailingWhitespace { get; set; }
+    /// <summary>
+    /// Whether to allow horizontal resizing similar to a textarea
+    /// </summary>
+    /// <value></value>
+    [Parameter] public bool HighlightWhitespace { get; set; }
+    /// <summary>
     /// Additional attributes to be applied to the container element
     /// </summary>
     /// <value></value>

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
@@ -156,6 +156,16 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     /// <value></value>
     [Parameter] public UnifiedMergeConfig? MergeViewConfiguration { get; set; }
     /// <summary>
+    /// Whether to allow horizontal resizing similar to a textarea
+    /// </summary>
+    /// <value></value>
+    [Parameter] public bool HighlightTrailingWhitespace { get; set; }
+    /// <summary>
+    /// Whether to allow horizontal resizing similar to a textarea
+    /// </summary>
+    /// <value></value>
+    [Parameter] public bool HighlightWhitespace { get; set; }
+    /// <summary>
     /// Additional attributes to be applied to the container element
     /// </summary>
     /// <value></value>
@@ -201,7 +211,9 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             LineWrapping,
             LintDocument is not null,
             MergeViewConfiguration,
-            FileNameOrExtension
+            FileNameOrExtension,
+            HighlightTrailingWhitespace,
+            HighlightWhitespace
         );
         try {
             if (IsWASM)
@@ -301,6 +313,14 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
         if (Config.MergeViewConfiguration != MergeViewConfiguration) {
             Config.MergeViewConfiguration = MergeViewConfiguration;
             await CmJsInterop.PropertySetters.SetUnifiedMergeView();
+        }
+        if (Config.HighlightTrailingWhitespace != HighlightTrailingWhitespace) {
+            Config.HighlightTrailingWhitespace = HighlightTrailingWhitespace;
+            await CmJsInterop.PropertySetters.SetHighlightTrailingWhitespace();
+        }
+        if (Config.HighlightWhitespace != HighlightWhitespace) {
+            Config.HighlightWhitespace = HighlightWhitespace;
+            await CmJsInterop.PropertySetters.SetHighlightWhitespace();
         }
         shouldRender = true;
     }

--- a/CodeMirror6/Commands/CMConfigurationSetters.cs
+++ b/CodeMirror6/Commands/CMConfigurationSetters.cs
@@ -134,6 +134,16 @@ internal class CMSetters(
         config.MergeViewConfiguration
     );
 
+    internal Task SetHighlightTrailingWhitespace() => cmJsInterop.ModuleInvokeVoidAsync(
+        "setHighlightTrailingWhitespace",
+        config.HighlightTrailingWhitespace
+    );
+
+    internal Task SetHighlightWhitespace() => cmJsInterop.ModuleInvokeVoidAsync(
+        "setHighlightWhitespace",
+        config.HighlightWhitespace
+    );
+
     internal Task<List<string>?> GetAllSupportedLanguageNames() => cmJsInterop.ModuleInvokeAsync<List<string>>(
         "getAllSupportedLanguageNames"
     );

--- a/CodeMirror6/Converters/JsonStringValueAttribute.cs
+++ b/CodeMirror6/Converters/JsonStringValueAttribute.cs
@@ -1,12 +1,15 @@
 namespace GaelJ.BlazorCodeMirror6.Converters;
 
+/// <summary>
+/// Specifies the string value of a field when serialized to JSON.
+/// </summary>
+/// <param name="value"></param>
 [AttributeUsage(AttributeTargets.Field)]
-public class JsonStringValueAttribute : Attribute
+public class JsonStringValueAttribute(string value) : Attribute
 {
-    public string Value { get; }
-
-    public JsonStringValueAttribute(string value)
-    {
-        Value = value;
-    }
+    /// <summary>
+    /// The string value of the field when serialized to JSON.
+    /// </summary>
+    /// <value></value>
+    public string Value { get; } = value;
 }

--- a/CodeMirror6/Models/CodeMirrorConfiguration.cs
+++ b/CodeMirror6/Models/CodeMirrorConfiguration.cs
@@ -21,6 +21,8 @@ namespace GaelJ.BlazorCodeMirror6.Models;
 /// <param name="lintingEnabled"></param>
 /// <param name="mergeViewConfiguration"></param>
 /// <param name="fileNameOrExtension"></param>
+/// <param name="highlightTrailingWhitespace"></param>
+/// <param name="highlightWhitespace"></param>
 public class CodeMirrorConfiguration(
     string? doc,
     string? placeholder,
@@ -36,7 +38,9 @@ public class CodeMirrorConfiguration(
     bool lineWrapping,
     bool lintingEnabled,
     UnifiedMergeConfig? mergeViewConfiguration,
-    string? fileNameOrExtension)
+    string? fileNameOrExtension,
+    bool highlightTrailingWhitespace,
+    bool highlightWhitespace)
 {
 
     /// <summary>
@@ -114,4 +118,14 @@ public class CodeMirrorConfiguration(
     /// Unified merged view configuration
     /// </summary>
     [JsonPropertyName("mergeViewConfiguration")] internal UnifiedMergeConfig? MergeViewConfiguration { get; set; } = mergeViewConfiguration;
+
+    /// <summary>
+    /// Whether to highlight trailing whitespace
+    /// </summary>
+    [JsonPropertyName("highlightTrailingWhitespace")] public bool HighlightTrailingWhitespace { get; internal set; } = highlightTrailingWhitespace;
+
+    /// <summary>
+    /// Whether to highlight whitespace
+    /// </summary>
+    [JsonPropertyName("highlightWhitespace")] public bool HighlightWhitespace { get; internal set; } = highlightWhitespace;
 }

--- a/CodeMirror6/Models/CodeMirrorLanguage.cs
+++ b/CodeMirror6/Models/CodeMirrorLanguage.cs
@@ -607,7 +607,7 @@ public enum CodeMirrorLanguage
     /// <summary>
     /// Lezer
     /// </summary>
-    Lezer,
+    [JsonStringValue("Lezer")] Lezer,
 
     /// <summary>
     /// Markdown
@@ -617,7 +617,7 @@ public enum CodeMirrorLanguage
     /// <summary>
     /// Mermaid
     /// </summary>
-    Mermaid,
+    [JsonStringValue("Mermaid")] Mermaid,
 
     /// <summary>
     /// Python

--- a/CodeMirror6/Models/CodeMirrorLanguage.cs
+++ b/CodeMirror6/Models/CodeMirrorLanguage.cs
@@ -13,7 +13,7 @@ public enum CodeMirrorLanguage
     /// <summary>
     /// Plain text
     /// </summary>
-    [JsonStringValue("PlainText")] PlainText,
+    [JsonStringValue("Plain Text")] PlainText,
 
     /// <summary>
     /// APL

--- a/CodeMirror6/Models/CodeMirrorLanguage.cs
+++ b/CodeMirror6/Models/CodeMirrorLanguage.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json.Serialization;
 using GaelJ.BlazorCodeMirror6.Converters;
 
@@ -733,4 +734,18 @@ public enum CodeMirrorLanguage
     /// YAML
     /// </summary>
     [JsonStringValue("YAML")] Yaml,
+}
+
+/// <summary>
+/// Extension methods for the <see cref="CodeMirrorLanguage"/> enum
+/// </summary>
+public static class CodeMirrorLanguageExtensions
+{
+    /// <summary>
+    /// Returns the display name of the language
+    /// </summary>
+    /// <param name="language"></param>
+    /// <returns></returns>
+    public static string DisplayName(this CodeMirrorLanguage language) =>
+        language.GetType().GetField(language.ToString())?.GetCustomAttribute<JsonStringValueAttribute>()?.Value ?? language.ToString();
 }

--- a/CodeMirror6/Models/CodeMirrorSetup.cs
+++ b/CodeMirror6/Models/CodeMirrorSetup.cs
@@ -129,4 +129,9 @@ public readonly record struct CodeMirrorSetup
     /// Bind value mode of the text area
     /// </summary>
     [JsonPropertyName("bindValueMode")] public DocumentBindMode BindMode { get; init; } = DocumentBindMode.OnLostFocus;
+
+    /// <summary>
+    /// Can the user scroll past the end of the document
+    /// </summary>
+    [JsonPropertyName("scrollPastEnd")] public bool ScrollPastEnd { get; init; } = false;
 }

--- a/CodeMirror6/NodeLib/src/CmConfiguration.ts
+++ b/CodeMirror6/NodeLib/src/CmConfiguration.ts
@@ -19,6 +19,8 @@ export class CmConfiguration {
     public lineWrapping: boolean
     public lintingEnabled: boolean
     public mergeViewConfiguration: UnifiedMergeConfig | null
+    public highlightTrailingWhitespace: boolean
+    public highlightWhitespace: boolean
 }
 
 export interface UnifiedMergeConfig {

--- a/CodeMirror6/NodeLib/src/CmFileUpload.ts
+++ b/CodeMirror6/NodeLib/src/CmFileUpload.ts
@@ -37,11 +37,13 @@ export function getFileUploadExtensions(id: string, setup: CmSetup)
 
     const dragAndDropHandler = EditorView.domEventHandlers({
         dragenter(event, view) {
+            if (!event.dataTransfer?.files.length) return
             event.preventDefault()
             overlay.style.display = 'flex'
             depth++
         },
         dragleave(event, view) {
+            if (!event.dataTransfer?.files.length) return
             event.preventDefault();
             depth--
             if (depth === 0) {
@@ -49,10 +51,12 @@ export function getFileUploadExtensions(id: string, setup: CmSetup)
             }
         },
         dragover(event, view) {
+            if (!event.dataTransfer?.files.length) return
             event.preventDefault()
             overlay.style.display = 'flex'
         },
         drop(event, view) {
+            if (!event.dataTransfer?.files.length) return
             const transfer = event.dataTransfer
             if (transfer?.files) {
                 overlay.style.display = 'none'

--- a/CodeMirror6/NodeLib/src/CmInstance.ts
+++ b/CodeMirror6/NodeLib/src/CmInstance.ts
@@ -24,6 +24,8 @@ export class CmInstance
     public emojiReplacerCompartment: Compartment = new Compartment
     public lineWrappingCompartment: Compartment = new Compartment
     public unifiedMergeViewCompartment: Compartment = new Compartment
+    public highlightTrailingWhitespaceCompartment: Compartment = new Compartment
+    public highlightWhitespaceCompartment: Compartment = new Compartment
 }
 
 export const CMInstances: { [id: string]: CmInstance}  = {}

--- a/CodeMirror6/NodeLib/src/CmLanguage.ts
+++ b/CodeMirror6/NodeLib/src/CmLanguage.ts
@@ -29,7 +29,7 @@ export async function getLanguage(languageName: string, fileNameOrExtension: str
     }
     console.log("getLanguage: " + languageName)
     switch (languageName) {
-        case "PlainText":
+        case "Plain Text":
             return null
         case "Lezer":
             return lezer()

--- a/CodeMirror6/NodeLib/src/CmSetup.ts
+++ b/CodeMirror6/NodeLib/src/CmSetup.ts
@@ -27,4 +27,5 @@ export class CmSetup
     public fileIcon: string
     public bindValueMode: string
     public krokiUrl: string
+    public scrollPastEnd: boolean
 }

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -1,7 +1,7 @@
 import {
     EditorView, keymap, highlightSpecialChars, drawSelection, highlightActiveLine, dropCursor,
-    rectangularSelection, crosshairCursor, ViewUpdate,
-    lineNumbers, highlightActiveLineGutter, placeholder, scrollPastEnd,
+    rectangularSelection, crosshairCursor, ViewUpdate, lineNumbers, highlightActiveLineGutter,
+    placeholder, scrollPastEnd, highlightTrailingWhitespace, highlightWhitespace
 } from "@codemirror/view"
 import { EditorState, SelectionRange, Text } from "@codemirror/state"
 import {
@@ -91,6 +91,8 @@ export async function initCodeMirror(
             indentationMarkers(),
             CMInstances[id].lineWrappingCompartment.of(initialConfig.lineWrapping ? EditorView.lineWrapping : []),
             CMInstances[id].unifiedMergeViewCompartment.of(initialConfig.mergeViewConfiguration ? unifiedMergeView(initialConfig.mergeViewConfiguration) : []),
+            CMInstances[id].highlightTrailingWhitespaceCompartment.of(initialConfig.highlightTrailingWhitespace ? highlightTrailingWhitespace() : []),
+            CMInstances[id].highlightWhitespaceCompartment.of(initialConfig.highlightWhitespace ? highlightWhitespace() : []),
 
             EditorView.updateListener.of(async (update) => { await updateListenerExtension(id, update) }),
             keymap.of([
@@ -300,6 +302,18 @@ export async function setLanguage(id: string, languageName: string, fileNameOrEx
 export function setMentionCompletions(id: string, mentionCompletions: Completion[]) {
     setCachedCompletions(mentionCompletions)
     forceRedraw(id)
+}
+
+export function setHighlightTrailingWhitespace(id: string, value: boolean) {
+    CMInstances[id].view.dispatch({
+        effects: CMInstances[id].highlightTrailingWhitespaceCompartment.reconfigure(value ? highlightTrailingWhitespace() : [])
+    })
+}
+
+export function setHighlightWhitespace(id: string, value: boolean) {
+    CMInstances[id].view.dispatch({
+        effects: CMInstances[id].highlightWhitespaceCompartment.reconfigure(value ? highlightWhitespace() : [])
+    })
 }
 
 export function forceRedraw(id: string) {

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -1,7 +1,7 @@
 import {
     EditorView, keymap, highlightSpecialChars, drawSelection, highlightActiveLine, dropCursor,
     rectangularSelection, crosshairCursor, ViewUpdate,
-    lineNumbers, highlightActiveLineGutter, placeholder
+    lineNumbers, highlightActiveLineGutter, placeholder, scrollPastEnd,
 } from "@codemirror/view"
 import { EditorState, SelectionRange, Text } from "@codemirror/state"
 import {
@@ -16,10 +16,11 @@ import {
     indentUnit, defaultHighlightStyle, syntaxHighlighting, indentOnInput, bracketMatching,
     foldGutter, foldKeymap,
 } from "@codemirror/language"
+import { languages } from "@codemirror/language-data"
 import { unifiedMergeView } from "@codemirror/merge"
 import { autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap, Completion } from "@codemirror/autocomplete"
 import { searchKeymap, highlightSelectionMatches } from "@codemirror/search"
-import { linter, lintKeymap } from "@codemirror/lint"
+import { linter, lintGutter, lintKeymap } from "@codemirror/lint"
 import { CmInstance, CMInstances } from "./CmInstance"
 import { CmConfiguration, UnifiedMergeConfig } from "./CmConfiguration"
 import { getDynamicHeaderStyling } from "./CmDynamicMarkdownHeaderStyling"
@@ -55,7 +56,6 @@ import { DotNet } from "@microsoft/dotnet-js-interop"
 import { markdownTableExtension } from "./CmMarkdownTable"
 import { dynamicDiagramsExtension } from "./CmDiagrams"
 import { hideMarksExtension } from "./CmHideMarkdownMarks"
-import { languages } from "@codemirror/language-data"
 
 /**
  * Initialize a new CodeMirror instance
@@ -145,15 +145,18 @@ export async function initCodeMirror(
         if (setup.syntaxHighlighting === true) extensions.push(syntaxHighlighting(defaultHighlightStyle, { fallback: true }))
         if (setup.bracketMatching === true) extensions.push(bracketMatching())
         if (setup.closeBrackets === true) extensions.push(closeBrackets())
-        if (setup.autocompletion === true) extensions.push(autocompletion({}))
+        if (setup.autocompletion === true) extensions.push(autocompletion())
         if (setup.rectangularSelection === true) extensions.push(rectangularSelection())
         if (setup.crossHairSelection === true) extensions.push(crosshairCursor())
         if (setup.highlightActiveLine === true) extensions.push(highlightActiveLine())
         if (setup.highlightSelectionMatches === true) extensions.push(highlightSelectionMatches())
+        if (setup.scrollPastEnd === true) extensions.push(scrollPastEnd())
+        if (setup.allowMultipleSelections === true) extensions.push(EditorState.allowMultipleSelections.of(true))
 
         if (initialConfig.lintingEnabled === true || setup.bindValueMode == "OnDelayedInput")
             extensions.push(linter(async view => await externalLintSource(view, dotnetHelper), getExternalLinterConfig()))
-        if (setup.allowMultipleSelections === true) extensions.push(EditorState.allowMultipleSelections.of(true))
+        if (initialConfig.lintingEnabled === true)
+            extensions.push(lintGutter())
 
         extensions.push(...getFileUploadExtensions(id, setup))
 

--- a/Examples.BlazorServer/Examples.BlazorServer.csproj
+++ b/Examples.BlazorServer/Examples.BlazorServer.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
+++ b/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Sentry.AspNetCore" Version="3.41.4" />

--- a/Examples.BlazorWasm/Examples.BlazorWasm.csproj
+++ b/Examples.BlazorWasm/Examples.BlazorWasm.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser-wasm" />

--- a/Examples.Common/Example.razor
+++ b/Examples.Common/Example.razor
@@ -10,11 +10,8 @@
 
 <label for="Language">Language</label>
 <select @bind=@Language id="Language">
-    @foreach (var language in Languages)
-    {
-        var languageDisplayName = language.GetType().GetField(language.ToString())?.GetCustomAttribute<GaelJ.BlazorCodeMirror6.Converters.JsonStringValueAttribute>()?.Value;
-
-        <option value="@language">@languageDisplayName</option>
+    @foreach (var language in Languages) {
+        <option value="@language">@language.DisplayName()</option>
     }
 </select>
 

--- a/Examples.Common/Example.razor
+++ b/Examples.Common/Example.razor
@@ -268,6 +268,7 @@
         HighlightActiveLineGutter = false,
         HighlightSelectionMatches = false,
         ScrollToEnd = true,
+        ScrollPastEnd = true,
         BindMode = DocumentBindMode.OnDelayedInput,
     };
     private UnifiedMergeConfig? PreviousMergeViewConfiguration;

--- a/Examples.Common/Example.razor
+++ b/Examples.Common/Example.razor
@@ -72,6 +72,20 @@
     }
 </div>
 
+<div class="d-block">
+    <label for="HighlightTrailingWhitespace">Highlight Trailing Whitespace</label>
+    <input id="HighlightTrailingWhitespace" type="checkbox" checked=@HighlightTrailingWhitespace @onchange=@(async v => {
+        HighlightTrailingWhitespace = (v.Value as bool?) == true;
+        await InvokeAsync(StateHasChanged);
+    }) />
+
+    <label for="HighlightWhitespace">Highlight Whitespace</label>
+    <input id="HighlightWhitespace" type="checkbox" checked=@HighlightWhitespace @onchange=@(async v => {
+        HighlightWhitespace = (v.Value as bool?) == true;
+        await InvokeAsync(StateHasChanged);
+    }) />
+</div>
+
 
 <CodeMirror6Wrapper
     IsWASM=@IsWASM
@@ -92,6 +106,8 @@
     ReadOnly=false
     LineWrapping=@LineWrapping
     MergeViewConfiguration=@MergeViewConfiguration
+    HighlightTrailingWhitespace=@HighlightTrailingWhitespace
+    HighlightWhitespace=@HighlightWhitespace
     style="max-width: 100%; max-height: 60em; "
 >
     <ContentBefore Context="c">
@@ -257,6 +273,8 @@
     private bool ReplaceEmojiCodes = false;
     private bool LineWrapping = true;
     private bool MergeViewEnabled = false;
+    private bool HighlightTrailingWhitespace = true;
+    private bool HighlightWhitespace = false;
     private List<CodeMirrorLanguage> Languages =>
         Enum.GetValues<CodeMirrorLanguage>()
             .OrderBy(l => l == CodeMirrorLanguage.PlainText ? 0 : 1)

--- a/Examples.Common/Examples.Common.csproj
+++ b/Examples.Common/Examples.Common.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/Examples.Common/_Imports.razor
+++ b/Examples.Common/_Imports.razor
@@ -9,4 +9,3 @@
 @using GaelJ.BlazorCodeMirror6.Commands
 @using GaelJ.BlazorCodeMirror6.Models
 @using System.Linq
-@using System.Reflection

--- a/NEW_CHANGELOG.md
+++ b/NEW_CHANGELOG.md
@@ -1,21 +1,14 @@
 ### ✨ Introduce new features
 
-- Implement configurable Unified Merge View
-- Support and dynamically load 145 languages
-- Allow specifying FileNameOrExtension to detect language automatically (instead of specifying Language parameter)
+- Add DisplayName() extension to CodeMirrorLanguage enum
+- Allow scrolling past the end of the document
+- Implement white space & trailing white space highlighting
 
-### ⚡️ Improve performance
+### 🐛 Fix a bug
 
-- Use record instead of class for interop DTOs: CodeMirrorCompletion/Section, CodeMirrorDiagnostic
+- Fix dragging text was highjacked by the file drag overlay
+- Fix empty language definitions in example
 
-### ⬆️ Upgrade dependencies
+### ✏️ Fix typos
 
-- Update dependencies: Sentry in examples projects ; languages, merge, babel in js
-
-### 📝 Add or update documentation
-
-- Add csv mode in README.md todo
-
-### 🚚 Move or rename resources (e.g., files, paths)
-
-- Move GetMentionCompletions in example, to dedicated file
+- Display Plain Text language name with space


### PR DESCRIPTION
### ✨ Introduce new features

- Add DisplayName() extension to CodeMirrorLanguage enum
- Allow scrolling past the end of the document
- Implement white space & trailing white space highlighting

### 🐛 Fix a bug

- Fix dragging text was highjacked by the file drag overlay
- Fix empty language definitions in example

### ✏️ Fix typos

- Display Plain Text language name with space
