### PR TITLE
Add linter for Maximum document length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.4.4 - 2024-02-11
+
+### ✨ Introduce new features
+
+- Add an optional linter for Maximum document length
+
+### 🐛 Fix a bug
+
+- Don't try to upload files if no callback was defined
+- Fix any text was pasted as markdown table
+- Fix hitting backspace on line before horizontal rule would delete it
+- Fix html rendering of markdown tables skipped empty cells
+- Focus the editor when full screen is toggled
+- Prevent second scroll bar from appearing depending on the width in fullscreen
+
+### 📝 Add or update documentation
+
+- Add ReadOnly checkbox to example
+
+### 🔇 Remove logs
+
+- Don't log full editor text, only length and only if changed
+
 ## 0.4.3 - 2024-02-10
 
 ### 🐛 Fix a bug

--- a/CodeMirror6/CodeMirror6.csproj
+++ b/CodeMirror6/CodeMirror6.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>GaelJ.BlazorCodeMirror6</AssemblyName>
     <IsPackable>true</IsPackable>
     <PackageId>GaelJ.BlazorCodeMirror6</PackageId>
-    <Version>0.4.3</Version>
+    <Version>0.4.4</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/CodeMirror6/CodeMirror6Wrapper.razor
+++ b/CodeMirror6/CodeMirror6Wrapper.razor
@@ -42,6 +42,7 @@
             Width="@Width"
             MaxHeight="@MaxHeight"
             MaxWidth="@MaxWidth"
+            MaxDocumentLength="@MaxDocumentLength"
         />
     </ChildContent>
     <ErrorContent Context="c">

--- a/CodeMirror6/CodeMirror6Wrapper.razor.cs
+++ b/CodeMirror6/CodeMirror6Wrapper.razor.cs
@@ -176,6 +176,10 @@ public partial class CodeMirror6Wrapper : ComponentBase
     /// <value></value>
     [Parameter] public string? MaxHeight { get; set; }
     /// <summary>
+    /// Optional maximum document length, in characters. A linting error will be raised if the document exceeds this length.
+    /// </summary>
+    [Parameter] public int? MaxDocumentLength { get; set; }
+    /// <summary>
     /// Additional attributes to be applied to the container element
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInvokables.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInvokables.cs
@@ -23,8 +23,8 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     /// <returns></returns>
     [JSInvokable] public async Task DocChangedFromJS(string value)
     {
-        if (Setup.DebugLogs) Logger.LogInformation("DocChangedFromJS: {value}", value);
         if (Doc?.Replace("\r", "") == value?.Replace("\r", "")) return;
+        if (Setup.DebugLogs) Logger.LogInformation("DocChangedFromJS: {length}", value?.Length);
         Doc = value?.Replace("\r", "") ?? "";
         Config.Doc = Doc;
         await DocChanged.InvokeAsync(Doc);
@@ -37,8 +37,8 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     /// <returns></returns>
     [JSInvokable] public async Task FocusChangedFromJS(bool value)
     {
-        if (Setup.DebugLogs) Logger.LogInformation("FocusChangedFromJS: {value}", value);
         if (State.HasFocus == value) return;
+        if (Setup.DebugLogs) Logger.LogInformation("FocusChangedFromJS: {value}", value);
         State.HasFocus = value;
         await FocusChanged.InvokeAsync(State.HasFocus);
     }
@@ -74,7 +74,7 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     /// <returns></returns>
     [JSInvokable] public async Task<List<CodeMirrorDiagnostic>> LintingRequestedFromJS(string document)
     {
-        if (Setup.DebugLogs) Logger.LogInformation("LintingRequestedFromJS: {document}", document);
+        if (Setup.DebugLogs) Logger.LogInformation("LintingRequestedFromJS: {length}", document.Length);
         if (Setup.BindMode == DocumentBindMode.OnDelayedInput) {
             await DocChangedFromJS(document);
         }

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
@@ -246,7 +246,8 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             HighlightTrailingWhitespace,
             HighlightWhitespace,
             LocalStorageKey,
-            FullScreen
+            FullScreen,
+            UploadBrowserFile is not null
         );
         try {
             if (IsWASM)
@@ -366,6 +367,10 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             }
             if (Config.FullScreen != FullScreen) {
                 Config.FullScreen = FullScreen;
+                updated = true;
+            }
+            if (Config.SupportFileUpload != (UploadBrowserFile is not null)) {
+                Config.SupportFileUpload = UploadBrowserFile is not null;
                 updated = true;
             }
             if (updated)

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
@@ -180,6 +180,10 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     /// <value></value>
     [Parameter] public string? MaxHeight { get; set; }
     /// <summary>
+    /// Optional maximum document length, in characters. A linting error will be raised if the document exceeds this length.
+    /// </summary>
+    [Parameter] public int? MaxDocumentLength { get; set; }
+    /// <summary>
     /// Additional attributes to be applied to the container element
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
@@ -247,7 +251,8 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             HighlightWhitespace,
             LocalStorageKey,
             FullScreen,
-            UploadBrowserFile is not null
+            UploadBrowserFile is not null,
+            MaxDocumentLength
         );
         try {
             if (IsWASM)
@@ -371,6 +376,10 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             }
             if (Config.SupportFileUpload != (UploadBrowserFile is not null)) {
                 Config.SupportFileUpload = UploadBrowserFile is not null;
+                updated = true;
+            }
+            if (Config.MaxDocumentLength != MaxDocumentLength) {
+                Config.MaxDocumentLength = MaxDocumentLength;
                 updated = true;
             }
             if (updated)

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.css
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.css
@@ -135,7 +135,7 @@
     flex-direction: column;
     top: 0px;
     left: 0px;
-    overflow: auto;
+    overflow: hidden;
     width: 100vw;
     height: 100vh;
 }

--- a/CodeMirror6/Models/CodeMirrorConfiguration.cs
+++ b/CodeMirror6/Models/CodeMirrorConfiguration.cs
@@ -25,6 +25,7 @@ namespace GaelJ.BlazorCodeMirror6.Models;
 /// <param name="highlightWhitespace"></param>
 /// <param name="localStorageKey"></param>
 /// <param name="fullScreen"></param>
+/// <param name="supportFileUpload"></param>
 public class CodeMirrorConfiguration(
     string? doc,
     string? placeholder,
@@ -44,9 +45,9 @@ public class CodeMirrorConfiguration(
     bool highlightTrailingWhitespace,
     bool highlightWhitespace,
     string? localStorageKey,
-    bool fullScreen)
+    bool fullScreen,
+    bool supportFileUpload)
 {
-
     /// <summary>
     /// The text to display in the editor
     /// </summary>
@@ -132,6 +133,7 @@ public class CodeMirrorConfiguration(
     /// Whether to highlight whitespace
     /// </summary>
     [JsonPropertyName("highlightWhitespace")] public bool HighlightWhitespace { get; internal set; } = highlightWhitespace;
+
     /// <summary>
     /// Optional local storage key to use for saving the document
     /// </summary>
@@ -140,4 +142,9 @@ public class CodeMirrorConfiguration(
     /// Whether to display the editor in full screen mode
     /// </summary>
     [JsonPropertyName("fullScreen")] public bool FullScreen { get; internal set; } = fullScreen;
+
+    /// <summary>
+    /// Whether to support file upload
+    /// </summary>
+    [JsonPropertyName("supportFileUpload")] public bool SupportFileUpload { get; internal set; } = supportFileUpload;
 }

--- a/CodeMirror6/Models/CodeMirrorConfiguration.cs
+++ b/CodeMirror6/Models/CodeMirrorConfiguration.cs
@@ -26,6 +26,7 @@ namespace GaelJ.BlazorCodeMirror6.Models;
 /// <param name="localStorageKey"></param>
 /// <param name="fullScreen"></param>
 /// <param name="supportFileUpload"></param>
+/// <param name="maxDocumentLength"></param>
 public class CodeMirrorConfiguration(
     string? doc,
     string? placeholder,
@@ -46,7 +47,8 @@ public class CodeMirrorConfiguration(
     bool highlightWhitespace,
     string? localStorageKey,
     bool fullScreen,
-    bool supportFileUpload)
+    bool supportFileUpload,
+    int? maxDocumentLength)
 {
     /// <summary>
     /// The text to display in the editor
@@ -147,4 +149,9 @@ public class CodeMirrorConfiguration(
     /// Whether to support file upload
     /// </summary>
     [JsonPropertyName("supportFileUpload")] public bool SupportFileUpload { get; internal set; } = supportFileUpload;
+
+    /// <summary>
+    /// The maximum length of the document
+    /// </summary>
+    [JsonPropertyName("maxDocumentLength")] public int? MaxDocumentLength { get; internal set; } = maxDocumentLength;
 }

--- a/CodeMirror6/NodeLib/src/CmColumns.ts
+++ b/CodeMirror6/NodeLib/src/CmColumns.ts
@@ -243,36 +243,34 @@ function findMaxColumnWidths(data: string[][]): number[] {
 }
 
 function parseCSV(csvData: string, separator: string): string[][] {
-    return csvData.split('\n').map((row) => extractAllRowCells(row, separator))
+    return csvData.trim().split('\n').map((row) => extractAllRowCells(row, separator))
 }
 
 export function csvToMarkdownTable(text: string, separator: string, withHeaders: boolean)
 {
-    if (text.trim().indexOf("\n") < 0 && text.indexOf(separator) < 0) return text;
-    var md = "\n\n";
-    const data = parseCSV(text, separator);
-    if (data.length <= 1) return text;
+    if (text.indexOf(separator) < 0) return text
+    var md = "\n\n"
+    const data = parseCSV(text, separator)
+    const maxWidths = findMaxColumnWidths(data)
+    if (data.length === 0) return text
+    if (data.length === 1) withHeaders = false
+    if (withHeaders === false) data.unshift(data[0].map(() => ""))
     data.forEach((line, lineIndex) => {
-        if (line.length > 0) {
-            var mdRow = "| ";
-            line.forEach((cell) => {
-                while (cell.indexOf("|") > 0)
-                    cell = cell.replace("|", "&#124;");
-                mdRow += cell + " | ";
-                if (lineIndex == 0 && !withHeaders) {
-                    md += "|  ";
-                }
+        var mdRow = ""
+        line.forEach((cell, cellIndex) => {
+            while (cell.indexOf("|") > 0)
+                cell = cell.replace("|", "&#124;")
+            mdRow += "| " + cell + (' '.repeat(maxWidths[cellIndex] - cell.length)) + " "
+        })
+        mdRow += "|"
+        if (lineIndex === 0) {
+            mdRow += "\n"
+            line.forEach((cell, cellIndex) => {
+                mdRow += "|-" + ('-'.repeat(maxWidths[cellIndex])) + "-"
             });
-            if ((lineIndex == 0 && !withHeaders) || (lineIndex == 1 && withHeaders)) {
-                if (lineIndex == 0)
-                    md += "  |\n";
-                line.forEach(() => {
-                    md += "|--";
-                });
-                md += "|\n";
-            }
-            md += mdRow + "\n";
+            mdRow += "|"
         }
-    });
-    return md;
+        md += mdRow + "\n"
+    })
+    return md
 }

--- a/CodeMirror6/NodeLib/src/CmConfiguration.ts
+++ b/CodeMirror6/NodeLib/src/CmConfiguration.ts
@@ -23,6 +23,7 @@ export class CmConfiguration {
     public highlightWhitespace: boolean
     public localStorageKey: string
     public fullScreen: boolean
+    public supportFileUpload: boolean
 }
 
 export interface UnifiedMergeConfig {

--- a/CodeMirror6/NodeLib/src/CmConfiguration.ts
+++ b/CodeMirror6/NodeLib/src/CmConfiguration.ts
@@ -24,6 +24,7 @@ export class CmConfiguration {
     public localStorageKey: string
     public fullScreen: boolean
     public supportFileUpload: boolean
+    public maxDocumentLength: number | null
 }
 
 export interface UnifiedMergeConfig {

--- a/CodeMirror6/NodeLib/src/CmFileUpload.ts
+++ b/CodeMirror6/NodeLib/src/CmFileUpload.ts
@@ -5,6 +5,15 @@ import { CMInstances } from "./CmInstance"
 import { consoleLog } from "./CmLogging"
 
 
+function isFileDragEvent(event: DragEvent): boolean {
+    let isFile = false
+    for (let i = 0; i < event.dataTransfer.types.length; i++) {
+        if (event.dataTransfer.types[i] == "Files")
+            isFile = true
+    }
+    return isFile
+}
+
 export function getFileUploadExtensions(id: string, setup: CmSetup)
 {
     const overlayId = `${id}-file-upload`
@@ -39,13 +48,13 @@ export function getFileUploadExtensions(id: string, setup: CmSetup)
 
     const dragAndDropHandler = EditorView.domEventHandlers({
         dragenter(event, view) {
-            if (!event.dataTransfer?.files.length) return
+            if (!CMInstances[id].config.supportFileUpload || !isFileDragEvent(event)) return
             event.preventDefault()
             overlay.style.display = 'flex'
             depth++
         },
         dragleave(event, view) {
-            if (!event.dataTransfer?.files.length) return
+            if (!CMInstances[id].config.supportFileUpload || !isFileDragEvent(event)) return
             event.preventDefault();
             depth--
             if (depth === 0) {
@@ -53,12 +62,13 @@ export function getFileUploadExtensions(id: string, setup: CmSetup)
             }
         },
         dragover(event, view) {
-            if (!event.dataTransfer?.files.length) return
+            if (!CMInstances[id].config.supportFileUpload || !isFileDragEvent(event)) return
             event.preventDefault()
             overlay.style.display = 'flex'
         },
         drop(event, view) {
-            if (!event.dataTransfer?.files.length) return
+            if (!CMInstances[id].config.supportFileUpload || !isFileDragEvent(event)) return
+            consoleLog(id, "drop")
             const transfer = event.dataTransfer
             if (transfer?.files) {
                 overlay.style.display = 'none'

--- a/CodeMirror6/NodeLib/src/CmHorizontalRule.ts
+++ b/CodeMirror6/NodeLib/src/CmHorizontalRule.ts
@@ -41,7 +41,7 @@ export const dynamicHrExtension = (enabled: boolean = true): Extension => {
                         const hrRegex = /^-{3,}$/
 
                         if (hrRegex.test(lineText)) {
-                            widgets.push(createHRDecorationWidget().range(from, to))
+                            widgets.push(createHRDecorationWidget().range(line.from, line.to))
                         }
                     }
                 },

--- a/CodeMirror6/NodeLib/src/CmMarkdownTable.ts
+++ b/CodeMirror6/NodeLib/src/CmMarkdownTable.ts
@@ -11,12 +11,12 @@ function markdownTableToHTML(markdownTable: string): string {
     let htmlTable = "";
 
     rows.forEach((row, index) => {
-        const isHeader = index === 0;
-        const tag = isHeader ? "th" : "td";
-        const cells = row.split('|').filter(cell => cell.trim() !== '').map(cell => cell.trim().replace(/-/g, ''));
-        if (cells.join('').trim() !== '')
-            htmlTable += `  <tr>${cells.map(cell => `<${tag}>${cell}</${tag}>`).join('')}</tr>\n`;
-    });
+        const isHeader = index === 0
+        const tag = isHeader ? "th" : "td"
+        const cells = row.trim().replace(/^\|/, '').replace(/\|$/, '').trim().split('|').map(cell => cell.trim())
+        if (cells.join('').trim().replace(/-/g, '') !== '')
+            htmlTable += `  <tr>${cells.map(cell => `<${tag}>${cell}</${tag}>`).join('')}</tr>\n`
+    })
 
     return htmlTable;
 }

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -392,7 +392,7 @@ export async function setConfiguration(id: string, newConfig: CmConfiguration) {
     if (oldConfig.highlightTrailingWhitespace !== newConfig.highlightTrailingWhitespace) effects.push(CMInstances[id].highlightTrailingWhitespaceCompartment.reconfigure(newConfig.highlightTrailingWhitespace ? highlightTrailingWhitespace() : []))
     if (oldConfig.highlightWhitespace !== newConfig.highlightWhitespace) effects.push(CMInstances[id].highlightWhitespaceCompartment.reconfigure(newConfig.highlightWhitespace ? highlightWhitespace() : []))
     if (oldConfig.localStorageKey !== newConfig.localStorageKey) setLocalStorageKey(id, newConfig.localStorageKey)
-    if (oldConfig.fullScreen !== newConfig.fullScreen) {}
+    if (oldConfig.fullScreen !== newConfig.fullScreen) view.focus()
     if (oldConfig.supportFileUpload !== newConfig.supportFileUpload) {}
     if (oldConfig.maxDocumentLength !== newConfig.maxDocumentLength) {}
 

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -203,7 +203,7 @@ export async function initCodeMirror(
                     const item = transfer.items[i]
                     consoleLog(id, "Item", item.kind, item.type)
                 }
-                if (transfer?.files && transfer.files.length > 0 && !transfer.types.includes('text/plain')) {
+                if (CMInstances[id].config.supportFileUpload && transfer?.files && transfer.files.length > 0 && !transfer.types.includes('text/plain')) {
                     uploadFiles(id, transfer.files, view)
                     event.preventDefault()
                 }

--- a/Examples.BlazorServer/Examples.BlazorServer.csproj
+++ b/Examples.BlazorServer/Examples.BlazorServer.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.4.3</Version>
+    <Version>0.4.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
+++ b/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.4.3</Version>
+    <Version>0.4.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Sentry.AspNetCore" Version="3.41.4" />

--- a/Examples.BlazorWasm/Examples.BlazorWasm.csproj
+++ b/Examples.BlazorWasm/Examples.BlazorWasm.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.4.3</Version>
+    <Version>0.4.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser-wasm" />

--- a/Examples.Common/Example.razor
+++ b/Examples.Common/Example.razor
@@ -86,6 +86,11 @@
     }) />
 </div>
 
+<label for="HighlightTrailingWhitespace">Read-only</label>
+<input id="HighlightTrailingWhitespace" type="checkbox" checked=@ReadOnly @onchange=@(async v => {
+    ReadOnly = (v.Value as bool?) == true;
+    await InvokeAsync(StateHasChanged);
+}) />
 
 <button class="btn btn-primary"
     @onclick=@(async () => {
@@ -117,7 +122,7 @@
     GetMentionCompletions=@GetMentionCompletions
     UploadFile=@UploadFile
     Editable
-    ReadOnly=false
+    ReadOnly=@ReadOnly
     LineWrapping=@LineWrapping
     MergeViewConfiguration=@MergeViewConfiguration
     HighlightTrailingWhitespace=@HighlightTrailingWhitespace
@@ -291,10 +296,12 @@
 @code
 {
     [Parameter] public bool IsWASM { get; set; }
+
     private string? Text = code;
     private string? Text2 = "# Example 2";
     private string? Text3;
     private int TabSize = 4;
+    private bool ReadOnly;
     private List<SelectionRange>? selectionRanges1;
     private List<SelectionRange>? selectionRanges2;
     private List<SelectionRange>? selectionRanges3;

--- a/Examples.Common/Example.razor
+++ b/Examples.Common/Example.razor
@@ -237,6 +237,7 @@
     LintDocument=@LintDocument
     AllowHorizontalResize
     AllowVerticalResize=false
+    MaxDocumentLength=10
 />
 
 <pre>@Text2?.Split("\n").Count() Line(s)</pre>

--- a/Examples.Common/Examples.Common.csproj
+++ b/Examples.Common/Examples.Common.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <Version>0.4.3</Version>
+    <Version>0.4.4</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/NEW_CHANGELOG.md
+++ b/NEW_CHANGELOG.md
@@ -1,3 +1,20 @@
+### ✨ Introduce new features
+
+- Add an optional linter for Maximum document length
+
 ### 🐛 Fix a bug
 
-- Fix crash in logging
+- Don't try to upload files if no callback was defined
+- Fix any text was pasted as markdown table
+- Fix hitting backspace on line before horizontal rule would delete it
+- Fix html rendering of markdown tables skipped empty cells
+- Focus the editor when full screen is toggled
+- Prevent second scroll bar from appearing depending on the width in fullscreen
+
+### 📝 Add or update documentation
+
+- Add ReadOnly checkbox to example
+
+### 🔇 Remove logs
+
+- Don't log full editor text, only length and only if changed


### PR DESCRIPTION
### ✨ Introduce new features

- Add an optional linter for Maximum document length

### 🐛 Fix a bug

- Don't try to upload files if no callback was defined
- Fix any text was pasted as markdown table
- Fix hitting backspace on line before horizontal rule would delete it
- Fix html rendering of markdown tables skipped empty cells
- Focus the editor when full screen is toggled
- Prevent second scroll bar from appearing depending on the width in fullscreen

### 📝 Add or update documentation

- Add ReadOnly checkbox to example

### 🔇 Remove logs

- Don't log full editor text, only length and only if changed
