### PR TITLE
Bugfixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": ".NET Core Launch (Blazor Server)",
+      "name": "Blazor Server",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
@@ -22,7 +22,7 @@
       }
     },
     {
-      "name": "Launch and Debug Standalone Blazor WebAssembly App",
+      "name": "Blazor WebAssembly",
       "type": "blazorwasm",
       "request": "launch",
       "cwd": "${workspaceFolder}/Examples.BlazorWasm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.4.5 - 2024-02-12
+
+### 🐛 Fix a bug
+
+- Check result of interop functions and quit if error
+- Ensure the original Setup.Id is used, even if Setup was overwritten
+- Fix another case of false detection of markdown tables
+- Prevent null refs in dispose()
+
+### 🔧 Add or update configuration files
+
+- Cleanup vs code debug names
+
+### 🥅 Catch errors
+
+- Catch ObjectDisposedException
+
 ## 0.4.4 - 2024-02-11
 
 ### ✨ Introduce new features

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor
@@ -20,7 +20,7 @@
         </div>
     }
 
-    <div id=@Setup.Id @attributes=@AdditionalAttributes style=@EditorStyle>
+    <div id=@SetupId @attributes=@AdditionalAttributes style=@EditorStyle>
     </div>
 
     <div id=@BottomBarId>

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInterop.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInterop.cs
@@ -33,14 +33,15 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
         private CMCommandDispatcher _commands = null!;
         public bool IsJSReady => _moduleTask.IsValueCreated && _moduleTask.Value.IsCompletedSuccessfully;
 
-        internal async Task ModuleInvokeVoidAsync(string method, params object?[] args)
+        internal async Task<bool> ModuleInvokeVoidAsync(string method, params object?[] args)
         {
 #pragma warning disable CS0168 // Variable is declared but never used
             try {
                 var module = await _moduleTask.Value;
-                if (module is null) return;
+                if (module is null) return false;
                 args = args.Prepend(cm6WrapperComponent.SetupId).ToArray();
                 await module.InvokeVoidAsync(method, args);
+                return true;
             }
             catch (ObjectDisposedException) {}
             catch (JSDisconnectedException) {}
@@ -53,8 +54,7 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
                 throw;
                 #endif
             }
-            finally {
-            }
+            return false;
 #pragma warning restore CS0168 // Variable is declared but never used
         }
 

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInterop.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInterop.cs
@@ -46,7 +46,8 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             catch (Exception ex)
             {
                 #if NET8_0_OR_GREATER
-                await cm6WrapperComponent.DispatchExceptionAsync(ex);
+                if (cm6WrapperComponent is not null)
+                    await cm6WrapperComponent.DispatchExceptionAsync(ex);
                 #else
                 throw;
                 #endif
@@ -71,7 +72,8 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             catch (Exception ex)
             {
                 #if NET8_0_OR_GREATER
-                await cm6WrapperComponent.DispatchExceptionAsync(ex);
+                if (cm6WrapperComponent is not null)
+                    await cm6WrapperComponent.DispatchExceptionAsync(ex);
                 return default;
                 #else
                 throw;

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInterop.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInterop.cs
@@ -39,7 +39,7 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             try {
                 var module = await _moduleTask.Value;
                 if (module is null) return;
-                args = args.Prepend(cm6WrapperComponent.Setup.Id).ToArray();
+                args = args.Prepend(cm6WrapperComponent.SetupId).ToArray();
                 await module.InvokeVoidAsync(method, args);
             }
             catch (JSDisconnectedException) {}
@@ -62,7 +62,7 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             try {
                 var module = await _moduleTask.Value;
                 if (module is null) return default;
-                args = args.Prepend(cm6WrapperComponent.Setup.Id).ToArray();
+                args = args.Prepend(cm6WrapperComponent.SetupId).ToArray();
                 return await module.InvokeAsync<T?>(method, args);
             }
             catch (JSDisconnectedException) {

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInterop.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.JsInterop.cs
@@ -42,6 +42,7 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
                 args = args.Prepend(cm6WrapperComponent.SetupId).ToArray();
                 await module.InvokeVoidAsync(method, args);
             }
+            catch (ObjectDisposedException) {}
             catch (JSDisconnectedException) {}
             catch (Exception ex)
             {
@@ -65,6 +66,9 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
                 if (module is null) return default;
                 args = args.Prepend(cm6WrapperComponent.SetupId).ToArray();
                 return await module.InvokeAsync<T?>(method, args);
+            }
+            catch (ObjectDisposedException) {
+                return default;
             }
             catch (JSDisconnectedException) {
                 return default;

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
@@ -194,10 +194,11 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     /// <returns></returns>
     public CMCommandDispatcher? CommandDispatcher => CmJsInterop?.CommandDispatcher;
 
-    private string LoadingDivId => $"{Setup.Id}_Loading";
-    private string ContainerId => $"{Setup.Id}_Container";
-    private string TopBarId => $"{Setup.Id}_TopBar";
-    private string BottomBarId => $"{Setup.Id}_BottomBar";
+    private string SetupId = null!;
+    private string LoadingDivId => $"{SetupId}_Loading";
+    private string ContainerId => $"{SetupId}_Container";
+    private string TopBarId => $"{SetupId}_TopBar";
+    private string BottomBarId => $"{SetupId}_BottomBar";
     private string ResizeStyle =>
           FullScreen ? "none"
         : AllowVerticalResize && AllowHorizontalResize ? "both"
@@ -279,6 +280,7 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     {
         if (CmJsInterop is null) {
             CmJsInterop = new CodeMirrorJsInterop(JSRuntime, this);
+            SetupId = Setup.Id;
             await CmJsInterop.PropertySetters.InitCodeMirror();
             if (GetMentionCompletions is not null) {
                 var mentionCompletions = await GetMentionCompletions();

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
@@ -281,10 +281,10 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     {
         if (CmJsInterop is null) {
             CmJsInterop = new CodeMirrorJsInterop(JSRuntime, this);
-            await CmJsInterop.PropertySetters.InitCodeMirror();
+            if (!await CmJsInterop.PropertySetters.InitCodeMirror()) return;
             if (GetMentionCompletions is not null) {
                 var mentionCompletions = await GetMentionCompletions();
-                await CmJsInterop.PropertySetters.SetMentionCompletions(mentionCompletions);
+                if (!await CmJsInterop.PropertySetters.SetMentionCompletions(mentionCompletions)) return;
             }
             IsCodeMirrorInitialized = true;
             await InvokeAsync(StateHasChanged);

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
@@ -232,6 +232,7 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     /// </summary>
     protected override async Task OnInitializedAsync()
     {
+        SetupId = Setup.Id;
         Config = new(
             Doc?.Replace("\r", ""),
             Placeholder,
@@ -280,7 +281,6 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     {
         if (CmJsInterop is null) {
             CmJsInterop = new CodeMirrorJsInterop(JSRuntime, this);
-            SetupId = Setup.Id;
             await CmJsInterop.PropertySetters.InitCodeMirror();
             if (GetMentionCompletions is not null) {
                 var mentionCompletions = await GetMentionCompletions();

--- a/CodeMirror6/Commands/CMConfigurationSetters.cs
+++ b/CodeMirror6/Commands/CMConfigurationSetters.cs
@@ -17,19 +17,19 @@ internal class CMSetters(
     /// Call the Javascript initialization
     /// </summary>
     /// <returns></returns>
-    internal Task InitCodeMirror() => cmJsInterop.ModuleInvokeVoidAsync(
+    internal Task<bool> InitCodeMirror() => cmJsInterop.ModuleInvokeVoidAsync(
         "initCodeMirror",
         _dotnetHelperRef,
         config,
         setup
     );
 
-    internal Task SetMentionCompletions(List<CodeMirrorCompletion> mentionCompletions) => cmJsInterop.ModuleInvokeVoidAsync(
+    internal Task<bool> SetMentionCompletions(List<CodeMirrorCompletion> mentionCompletions) => cmJsInterop.ModuleInvokeVoidAsync(
         "setMentionCompletions",
         mentionCompletions
     );
 
-    internal Task ForceRedraw() => cmJsInterop.ModuleInvokeVoidAsync(
+    internal Task<bool> ForceRedraw() => cmJsInterop.ModuleInvokeVoidAsync(
         "forceRedraw"
     );
 
@@ -37,7 +37,7 @@ internal class CMSetters(
         "getAllSupportedLanguageNames"
     );
 
-    internal Task SetConfiguration() => cmJsInterop.ModuleInvokeVoidAsync(
+    internal Task<bool> SetConfiguration() => cmJsInterop.ModuleInvokeVoidAsync(
         "setConfiguration",
         config
     );

--- a/CodeMirror6/NodeLib/src/CmColumns.ts
+++ b/CodeMirror6/NodeLib/src/CmColumns.ts
@@ -149,7 +149,6 @@ export async function columnLintSource(id: string, view: EditorView, separator: 
     try {
         const code = view.state.doc.toString()
         const data = parseCSV(code, separator)
-        if (data === null) return
         const nbCols = data[0].length
         const errors: Diagnostic[] = []
         for (let i = 1; i < data.length; i++) {
@@ -225,8 +224,12 @@ function extractAllRowCells(line: string, separator: string): string[] {
 
 function findMaxColumnWidthsInCsv(csvData: string, separator: string): number[] {
     const data = parseCSV(csvData, separator)
-    if (data === null) return []
     return findMaxColumnWidths(data)
+}
+
+function isCsvInvalid(data: string[][]): boolean
+{
+    return data.some((row) => row.length !== data[0].length)
 }
 
 function findMaxColumnWidths(data: string[][]): number[] {
@@ -245,9 +248,7 @@ function findMaxColumnWidths(data: string[][]): number[] {
 }
 
 function parseCSV(csvData: string, separator: string): string[][] {
-    const data = csvData.trim().split('\n').map((row) => extractAllRowCells(row, separator))
-    if (data.some((row) => row.length !== data[0].length)) return null
-    return data
+    return csvData.trim().split('\n').map((row) => extractAllRowCells(row, separator))
 }
 
 export function csvToMarkdownTable(text: string, separator: string, withHeaders: boolean)
@@ -255,7 +256,7 @@ export function csvToMarkdownTable(text: string, separator: string, withHeaders:
     if (text.indexOf(separator) < 0) return text
     var md = "\n\n"
     const data = parseCSV(text, separator)
-    if (data === null) return text
+    if (isCsvInvalid(data)) return text
     const maxWidths = findMaxColumnWidths(data)
     if (data.length === 0) return text
     if (data.length === 1) withHeaders = false

--- a/CodeMirror6/NodeLib/src/CmColumns.ts
+++ b/CodeMirror6/NodeLib/src/CmColumns.ts
@@ -149,6 +149,7 @@ export async function columnLintSource(id: string, view: EditorView, separator: 
     try {
         const code = view.state.doc.toString()
         const data = parseCSV(code, separator)
+        if (data === null) return
         const nbCols = data[0].length
         const errors: Diagnostic[] = []
         for (let i = 1; i < data.length; i++) {
@@ -224,6 +225,7 @@ function extractAllRowCells(line: string, separator: string): string[] {
 
 function findMaxColumnWidthsInCsv(csvData: string, separator: string): number[] {
     const data = parseCSV(csvData, separator)
+    if (data === null) return []
     return findMaxColumnWidths(data)
 }
 
@@ -243,7 +245,9 @@ function findMaxColumnWidths(data: string[][]): number[] {
 }
 
 function parseCSV(csvData: string, separator: string): string[][] {
-    return csvData.trim().split('\n').map((row) => extractAllRowCells(row, separator))
+    const data = csvData.trim().split('\n').map((row) => extractAllRowCells(row, separator))
+    if (data.some((row) => row.length !== data[0].length)) return null
+    return data
 }
 
 export function csvToMarkdownTable(text: string, separator: string, withHeaders: boolean)
@@ -251,6 +255,7 @@ export function csvToMarkdownTable(text: string, separator: string, withHeaders:
     if (text.indexOf(separator) < 0) return text
     var md = "\n\n"
     const data = parseCSV(text, separator)
+    if (data === null) return text
     const maxWidths = findMaxColumnWidths(data)
     if (data.length === 0) return text
     if (data.length === 1) withHeaders = false

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -568,9 +568,12 @@ function loadCss(url: string, cacheBust: boolean = true): Promise<void> {
  */
 export function dispose(id: string) {
     consoleLog(id, `Disposing of CodeMirror instance ${id}`)
-    CMInstances[id].dotNetHelper.dispose()
-    CMInstances[id].dotNetHelper = undefined
-    CMInstances[id].view.destroy()
-    CMInstances[id] = undefined
+    if (CMInstances[id].dotNetHelper !== undefined) {
+        CMInstances[id].dotNetHelper.dispose()
+        CMInstances[id].dotNetHelper = undefined
+    }
+    if (CMInstances[id].view !== undefined) {
+        CMInstances[id].view.destroy()
+    }
     delete CMInstances[id]
 }

--- a/NEW_CHANGELOG.md
+++ b/NEW_CHANGELOG.md
@@ -1,20 +1,14 @@
-### ✨ Introduce new features
-
-- Add an optional linter for Maximum document length
-
 ### 🐛 Fix a bug
 
-- Don't try to upload files if no callback was defined
-- Fix any text was pasted as markdown table
-- Fix hitting backspace on line before horizontal rule would delete it
-- Fix html rendering of markdown tables skipped empty cells
-- Focus the editor when full screen is toggled
-- Prevent second scroll bar from appearing depending on the width in fullscreen
+- Check result of interop functions and quit if error
+- Ensure the original Setup.Id is used, even if Setup was overwritten
+- Fix another case of false detection of markdown tables
+- Prevent null refs in dispose()
 
-### 📝 Add or update documentation
+### 🔧 Add or update configuration files
 
-- Add ReadOnly checkbox to example
+- Cleanup vs code debug names
 
-### 🔇 Remove logs
+### 🥅 Catch errors
 
-- Don't log full editor text, only length and only if changed
+- Catch ObjectDisposedException


### PR DESCRIPTION
### 🐛 Fix a bug

- Check result of interop functions and quit if error
- Ensure the original Setup.Id is used, even if Setup was overwritten
- Fix another case of false detection of markdown tables
- Prevent null refs in dispose()

### 🔧 Add or update configuration files

- Cleanup vs code debug names

### 🥅 Catch errors

- Catch ObjectDisposedException
