### PR TITLE
Fix crash on paste in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.7.3 - 2024-02-27
+
+### 🐛 Fix a bug
+
+- Fix possible null ref on startup
+- Replace \r\n with \n when pasting, to prevent crash in windows (#153)
+
+### 🗑️ Deprecate code that needs to be cleaned up
+
+- Remove useless exports (#144)
+
 ## 0.7.2 - 2024-02-25
 
 ### ✨ Introduce new features

--- a/CodeMirror6/CodeMirror6.csproj
+++ b/CodeMirror6/CodeMirror6.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>GaelJ.BlazorCodeMirror6</AssemblyName>
     <IsPackable>true</IsPackable>
     <PackageId>GaelJ.BlazorCodeMirror6</PackageId>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/CodeMirror6/NodeLib/src/CmCommands.ts
+++ b/CodeMirror6/NodeLib/src/CmCommands.ts
@@ -289,6 +289,7 @@ export async function cut(view: EditorView) {
 export async function paste(view: EditorView): Promise<boolean> {
     try {
         let text = await navigator.clipboard.readText()
+        text = text.replace(/\r\n/g, '\n')
         /*
         let items = await navigator.clipboard.read()
         const htmlItems = items.filter(item => item.types.includes("text/html"))

--- a/CodeMirror6/NodeLib/src/CmHelpers.ts
+++ b/CodeMirror6/NodeLib/src/CmHelpers.ts
@@ -10,7 +10,7 @@ const hasOverlap = (x1: number, x2: number, y1: number, y2: number) => {
 
 export const isCursorInRange = (state: EditorState, from: number, to: number) => {
     const id = getIdFromState(state)
-    if (!CMInstances[id].config.showMarkdownControlCharactersAroundCursor) return false
+    if (!CMInstances[id].config?.showMarkdownControlCharactersAroundCursor) return false
     return state.selection.ranges.some((range) => {
         return hasOverlap(from, to, range.from, range.to)
     })

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -63,7 +63,7 @@ import { createEditorWithId } from "./CmId"
 import { hyperLink } from './CmHyperlink'
 import { customArrowKeymap, customDeleteKeymap } from "./CmKeymap"
 
-export { csvToMarkdownTable, getCmInstance, cut, copy, paste }
+export { getCmInstance }
 
 /**
  * Initialize a new CodeMirror instance

--- a/Examples.BlazorServer/Examples.BlazorServer.csproj
+++ b/Examples.BlazorServer/Examples.BlazorServer.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
+++ b/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Sentry.AspNetCore" Version="4.1.0" />

--- a/Examples.BlazorWasm/Examples.BlazorWasm.csproj
+++ b/Examples.BlazorWasm/Examples.BlazorWasm.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser-wasm" />

--- a/Examples.Common/Examples.Common.csproj
+++ b/Examples.Common/Examples.Common.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/NEW_CHANGELOG.md
+++ b/NEW_CHANGELOG.md
@@ -1,7 +1,8 @@
-### ✨ Introduce new features
+### 🐛 Fix a bug
 
-- Support multiple cursors for arrow / shift / ctrl / ctrl-shift + arrow keys
+- Fix possible null ref on startup
+- Replace \r\n with \n when pasting, to prevent crash in windows (#153)
 
-### 📝 Add or update documentation
+### 🗑️ Deprecate code that needs to be cleaned up
 
-- Add an example using ref
+- Remove useless exports (#144)


### PR DESCRIPTION
### 🐛 Fix a bug

- Fix possible null ref on startup
- Replace \r\n with \n when pasting, to prevent crash in windows (#153)

### 🗑️ Deprecate code that needs to be cleaned up

- Remove useless exports (#144)
