### PR TITLE
Allow opening markdown links by passing them as query parameter value to a viewer URL + query parameter name + '='

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.5 - 2024-04-09
+
+### ✨ Introduce new features
+
+- Allow opening markdown links by passing them as query parameter value to a viewer URL + query parameter name + '='
+
+### 🐛 Fix a bug
+
+- Update images when bath path for links is initially set
+- Update links when bath path for links is initially set
+
 ## 0.8.4 - 2024-04-08
 
 ### 🐛 Fix a bug

--- a/CodeMirror6/CodeMirror6.csproj
+++ b/CodeMirror6/CodeMirror6.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>GaelJ.BlazorCodeMirror6</AssemblyName>
     <IsPackable>true</IsPackable>
     <PackageId>GaelJ.BlazorCodeMirror6</PackageId>
-    <Version>0.8.4</Version>
+    <Version>0.8.5</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/CodeMirror6/CodeMirror6Wrapper.razor
+++ b/CodeMirror6/CodeMirror6Wrapper.razor
@@ -52,6 +52,7 @@
             ScrollPastEnd="@ScrollPastEnd"
             ShowMarkdownControlCharactersAroundCursor="@ShowMarkdownControlCharactersAroundCursor"
             BasePathForLinks="@BasePathForLinks"
+            MarkdownViewPath="@MarkdownViewPath"
         />
     </ChildContent>
     <ErrorContent Context="c">

--- a/CodeMirror6/CodeMirror6Wrapper.razor.cs
+++ b/CodeMirror6/CodeMirror6Wrapper.razor.cs
@@ -212,6 +212,11 @@ public partial class CodeMirror6Wrapper : ComponentBase
     /// <value></value>
     [Parameter] public string? BasePathForLinks { get; set; }
     /// <summary>
+    /// The URL to the markdown viewer page, to optionally handle links to Markdown files. The original link will be appended as a query string parameter value
+    /// </summary>
+    /// <value></value>
+    [Parameter] public string? MarkdownViewPath { get; set; }
+    /// <summary>
     /// Whether to show the markdown control characters around the cursor
     /// </summary>
     [Parameter] public bool ShowMarkdownControlCharactersAroundCursor { get; init; } = true;

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
@@ -220,6 +220,11 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     /// <value></value>
     [Parameter] public string? BasePathForLinks { get; set; }
     /// <summary>
+    /// The URL to the markdown viewer page, to optionally handle links to Markdown files. The original link will be appended as a query string parameter value
+    /// </summary>
+    /// <value></value>
+    [Parameter] public string? MarkdownViewPath { get; set; }
+    /// <summary>
     /// Additional attributes to be applied to the container element
     /// </summary>
     [Parameter(CaptureUnmatchedValues = true)] public Dictionary<string, object>? AdditionalAttributes { get; set; }
@@ -304,7 +309,8 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             HighlightActiveLine,
             ShowMarkdownControlCharactersAroundCursor,
             EmbedUploadsAsDataUrls,
-            BasePathForLinks
+            BasePathForLinks,
+            MarkdownViewPath
         );
         try {
             if (IsWASM)
@@ -476,6 +482,10 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
             }
             if (Config.BasePathForLinks != BasePathForLinks) {
                 Config.BasePathForLinks = BasePathForLinks;
+                updated = true;
+            }
+            if (Config.MarkdownViewPath != MarkdownViewPath) {
+                Config.MarkdownViewPath = MarkdownViewPath;
                 updated = true;
             }
             if (LifeCycleCancellationTokenSource.IsCancellationRequested) return;

--- a/CodeMirror6/Models/CodeMirrorConfiguration.cs
+++ b/CodeMirror6/Models/CodeMirrorConfiguration.cs
@@ -37,6 +37,7 @@ namespace GaelJ.BlazorCodeMirror6.Models;
 /// <param name="showMarkdownControlCharactersAroundCursor"></param>
 /// <param name="embedUploadsAsDataUrls"></param>
 /// <param name="basePathForLinks"></param>
+/// <param name="markdownViewPath"></param>
 public class CodeMirrorConfiguration(
     string? doc,
     string? placeholder,
@@ -68,7 +69,8 @@ public class CodeMirrorConfiguration(
     bool highlightActiveLine,
     bool showMarkdownControlCharactersAroundCursor,
     bool embedUploadsAsDataUrls,
-    string? basePathForLinks)
+    string? basePathForLinks,
+    string? markdownViewPath)
 {
     /// <summary>
     /// The text to display in the editor
@@ -225,4 +227,10 @@ public class CodeMirrorConfiguration(
     /// </summary>
     /// <value></value>
     [JsonPropertyName("basePathForLinks")] public string? BasePathForLinks { get; set; } = basePathForLinks;
+
+    /// <summary>
+    /// The URL to the markdown viewer page, to optionally handle links to Markdown files. The original link will be appended as a query string parameter value
+    /// </summary>
+    /// <value></value>
+    [JsonPropertyName("markdownViewPath")] public string? MarkdownViewPath { get; set; } = markdownViewPath;
 }

--- a/CodeMirror6/NodeLib/src/CmConfiguration.ts
+++ b/CodeMirror6/NodeLib/src/CmConfiguration.ts
@@ -35,6 +35,7 @@ export class CmConfiguration {
     public highlightActiveLine: boolean
     public showMarkdownControlCharactersAroundCursor: boolean
     public basePathForLinks: string | null
+    public markdownViewPath: string | null
 }
 
 export interface UnifiedMergeConfig {

--- a/CodeMirror6/NodeLib/src/CmHyperlink.ts
+++ b/CodeMirror6/NodeLib/src/CmHyperlink.ts
@@ -19,6 +19,7 @@ export interface HyperLinkState
     at: number;
     url: string;
     baseUrl?: string;
+    viewer?: string;
 }
 
 class HyperLinkIcon extends WidgetType
@@ -41,6 +42,8 @@ class HyperLinkIcon extends WidgetType
         }
         else
             link.href = `${this.state.baseUrl}${this.state.url}`;
+        if (link.href.endsWith('.md') && this.state.viewer)
+            link.href = `${this.state.viewer}${encodeURIComponent(link.href)}`;
         link.target = '_blank';
         link.innerHTML = linkSvgImage;
         link.className = 'cm-hyper-link-icon';
@@ -57,6 +60,9 @@ function hyperLinkDecorations(view: EditorView, id: string)
     const basePathForLinks = (CMInstances[id] !== undefined && CMInstances[id].config.basePathForLinks)
         ? CMInstances[id].config.basePathForLinks.replace(/\/+$/, '') + "/"
         : '';
+    const markdownViewPath = (CMInstances[id] !== undefined && CMInstances[id].config.markdownViewPath)
+        ? CMInstances[id].config.markdownViewPath
+        : '';
 
     while ((match = anyLinkRegexp.exec(doc)) !== null) {
         const from = match.index;
@@ -66,6 +72,7 @@ function hyperLinkDecorations(view: EditorView, id: string)
                 at: to,
                 url: match[0],
                 baseUrl: basePathForLinks,
+                viewer: markdownViewPath,
             }),
             side: 1,
         });

--- a/CodeMirror6/NodeLib/src/CmInstance.ts
+++ b/CodeMirror6/NodeLib/src/CmInstance.ts
@@ -36,6 +36,7 @@ export class CmInstance
     public drawSelectionCompartment: Compartment = new Compartment
     public dropCursorCompartment: Compartment = new Compartment
     public scrollPastEndCompartment: Compartment = new Compartment
+    public hyperLinksCompartment: Compartment = new Compartment
 }
 
 export const CMInstances: { [id: string]: CmInstance}  = {}

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -138,7 +138,7 @@ export async function initCodeMirror(
             CMInstances[id].dropCursorCompartment.of(initialConfig.dropCursor ? dropCursor() : []),
             CMInstances[id].scrollPastEndCompartment.of(initialConfig.scrollPastEnd ? scrollPastEnd() : []),
             CMInstances[id].highlightActiveLineCompartment.of(initialConfig.highlightActiveLine ? highlightActiveLine() : []),
-            hyperLink(id),
+            CMInstances[id].hyperLinksCompartment.of(hyperLink(id)),
 
             EditorView.updateListener.of(async (update) => { await updateListenerExtension(id, update) }),
             linter(async view => maxDocLengthLintSource(id, view)),
@@ -399,6 +399,7 @@ export async function setConfiguration(id: string, newConfig: CmConfiguration) {
     if (oldConfig.dropCursor !== newConfig.dropCursor) effects.push(CMInstances[id].dropCursorCompartment.reconfigure(newConfig.dropCursor ? dropCursor() : []))
     if (oldConfig.scrollPastEnd !== newConfig.scrollPastEnd) effects.push(CMInstances[id].scrollPastEndCompartment.reconfigure(newConfig.scrollPastEnd ? scrollPastEnd() : []))
     if (oldConfig.highlightActiveLine !== newConfig.highlightActiveLine) effects.push(CMInstances[id].highlightActiveLineCompartment.reconfigure(newConfig.highlightActiveLine ? highlightActiveLine() : []))
+    if (oldConfig.basePathForLinks !== newConfig.basePathForLinks || oldConfig.markdownViewPath != newConfig.markdownViewPath) effects.push(CMInstances[id].hyperLinksCompartment.reconfigure(hyperLink(id)))
 
     CMInstances[id].config = newConfig
     if (effects.length > 0 || changes.length > 0)

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -377,7 +377,7 @@ export async function setConfiguration(id: string, newConfig: CmConfiguration) {
         else
             unfoldAll(CMInstances[id].view)
     }
-    if (oldConfig.autoFormatMarkdown !== newConfig.autoFormatMarkdown || oldConfig.previewImages !== newConfig.previewImages) {
+    if (oldConfig.autoFormatMarkdown !== newConfig.autoFormatMarkdown || oldConfig.previewImages !== newConfig.previewImages || oldConfig.basePathForLinks !== newConfig.basePathForLinks) {
         effects.push(CMInstances[id].markdownStylingCompartment.reconfigure(autoFormatMarkdownExtensions(id, newConfig.autoFormatMarkdown)))
         if (newConfig.languageName === "Markdown" && newConfig.autoFormatMarkdown)
             foldMarkdownDiagramCodeBlocks(CMInstances[id].view)

--- a/Examples.BlazorServer/Examples.BlazorServer.csproj
+++ b/Examples.BlazorServer/Examples.BlazorServer.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.8.4</Version>
+    <Version>0.8.5</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
+++ b/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.8.4</Version>
+    <Version>0.8.5</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Sentry.AspNetCore" Version="4.1.0" />

--- a/Examples.BlazorWasm/Examples.BlazorWasm.csproj
+++ b/Examples.BlazorWasm/Examples.BlazorWasm.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.8.4</Version>
+    <Version>0.8.5</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser-wasm" />

--- a/Examples.Common/Examples.Common.csproj
+++ b/Examples.Common/Examples.Common.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <Version>0.8.4</Version>
+    <Version>0.8.5</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/NEW_CHANGELOG.md
+++ b/NEW_CHANGELOG.md
@@ -1,3 +1,8 @@
+### ✨ Introduce new features
+
+- Allow opening markdown links by passing them as query parameter value to a viewer URL + query parameter name + '='
+
 ### 🐛 Fix a bug
 
-- Ensure base path for images is read dynamically
+- Update images when bath path for links is initially set
+- Update links when bath path for links is initially set


### PR DESCRIPTION
### ✨ Introduce new features

- Allow opening markdown links by passing them as query parameter value to a viewer URL + query parameter name + '='

### 🐛 Fix a bug

- Update images when bath path for links is initially set
- Update links when bath path for links is initially set
