### PR TITLE
Improve js interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.8.14 - 2024-11-14
+
+### ⚡️ Improve performance
+
+- Persist style tag created by CM6 after reloads, without needing any HeadOutlet in Blazor Server interactive (#187), as described in https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/static-server-rendering?view=aspnetcore-8.0
+- Dispose the JS object if the parent div does not exist ; robustify dispose method
+
+### 🐛 Fix a bug
+
+- Fix example 3 in server interactive mode
+- Fix null refs
+
+### 💥 Introduce breaking changes
+
+- Make parameter IsWASM obsolete: it can be automatically inferred from `OperatingSystem.IsBrowser()`
+
+### 📝 Add or update documentation
+
+- Add missing example3 page
+
 ## 0.8.13 - 2024-11-13
 
 ### ✨ Introduce new features

--- a/CodeMirror6/CodeMirror6.csproj
+++ b/CodeMirror6/CodeMirror6.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>GaelJ.BlazorCodeMirror6</AssemblyName>
     <IsPackable>true</IsPackable>
     <PackageId>GaelJ.BlazorCodeMirror6</PackageId>
-    <Version>0.8.13</Version>
+    <Version>0.8.14</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Examples.BlazorServer/Examples.BlazorServer.csproj
+++ b/Examples.BlazorServer/Examples.BlazorServer.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.8.13</Version>
+    <Version>0.8.14</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
+++ b/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.8.13</Version>
+    <Version>0.8.14</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Sentry.AspNetCore" Version="4.12.0" />

--- a/Examples.BlazorWasm/Examples.BlazorWasm.csproj
+++ b/Examples.BlazorWasm/Examples.BlazorWasm.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.8.13</Version>
+    <Version>0.8.14</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser-wasm" />

--- a/Examples.Common/Examples.Common.csproj
+++ b/Examples.Common/Examples.Common.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <Version>0.8.13</Version>
+    <Version>0.8.14</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/NEW_CHANGELOG.md
+++ b/NEW_CHANGELOG.md
@@ -1,3 +1,17 @@
-### ✨ Introduce new features
+### ⚡️ Improve performance
 
-- Add new parameter `InsertDroppedFileContents`. If true, text files will have their content extracted and inserted in the editor. If false, all file types dropped into the editor will be passed to the upload callback. In case of multiple mixed-type files, they will all be uploaded
+- Persist style tag created by CM6 after reloads, without needing any HeadOutlet in Blazor Server interactive (#187), as described in https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/static-server-rendering?view=aspnetcore-8.0
+- Dispose the JS object if the parent div does not exist ; robustify dispose method
+
+### 🐛 Fix a bug
+
+- Fix example 3 in server interactive mode
+- Fix null refs
+
+### 💥 Introduce breaking changes
+
+- Make parameter IsWASM obsolete: it can be automatically inferred from `OperatingSystem.IsBrowser()`
+
+### 📝 Add or update documentation
+
+- Add missing example3 page


### PR DESCRIPTION
### ⚡️ Improve performance

- Persist style tag created by CM6 after reloads, without needing any HeadOutlet in Blazor Server interactive (#187), as described in https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/static-server-rendering?view=aspnetcore-8.0
- Dispose the JS object if the parent div does not exist ; robustify dispose method

### 🐛 Fix a bug

- Fix example 3 in server interactive mode
- Fix null refs

### 💥 Introduce breaking changes

- Make parameter IsWASM obsolete: it can be automatically inferred from `OperatingSystem.IsBrowser()`

### 📝 Add or update documentation

- Add missing example3 page
