### PR TITLE
Fix #210

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-outdated-tool": {
-      "version": "4.6.4",
+      "version": "4.6.7",
       "commands": [
         "dotnet-outdated"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.9.2 - 2025-02-26
+
+### ⬆️ Upgrade dependencies
+
+- Update nuget packages
+
+### 🐛 Fix a bug
+
+- Fix logs not in color
+
+### 🗑️ Deprecate code that needs to be cleaned up
+
+- Explicitly loading BlazorCodeMirror6.bundle.scp.css is unneeded and broken (#210)
+
 ## 0.9.1 - 2024-12-11
 
 ### 🐛 Fix a bug

--- a/CodeMirror6/CodeMirror6.csproj
+++ b/CodeMirror6/CodeMirror6.csproj
@@ -40,8 +40,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.36" Condition="'$(TargetFramework)'=='net6.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.20" Condition="'$(TargetFramework)'=='net7.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.11" Condition="'$(TargetFramework)'=='net8.0'" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" Condition="'$(TargetFramework)'=='net9.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.13" Condition="'$(TargetFramework)'=='net8.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.2" Condition="'$(TargetFramework)'=='net9.0'" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />

--- a/CodeMirror6/CodeMirror6.csproj
+++ b/CodeMirror6/CodeMirror6.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>GaelJ.BlazorCodeMirror6</AssemblyName>
     <IsPackable>true</IsPackable>
     <PackageId>GaelJ.BlazorCodeMirror6</PackageId>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -65,7 +65,6 @@ export { requestLinterRefresh }
 let StyleTag: HTMLStyleElement | null = null
 
 export async function onUpdate() {
-    await loadCss("_content/GaelJ.BlazorCodeMirror6/GaelJ.BlazorCodeMirror6.bundle.scp.css")
     if (StyleTag) {
         const style = document.createElement('style');
         style.textContent = StyleTag.textContent
@@ -114,8 +113,6 @@ export async function initCodeMirror(
         dispose(id)
         return
     }
-
-    await loadCss("_content/GaelJ.BlazorCodeMirror6/GaelJ.BlazorCodeMirror6.bundle.scp.css")
 
     if (setup.debugLogs === true) {
         console.log(`Initializing CodeMirror instance ${id}`)

--- a/Examples.BlazorServer/Examples.BlazorServer.csproj
+++ b/Examples.BlazorServer/Examples.BlazorServer.csproj
@@ -10,7 +10,7 @@
     <SupportedPlatform Include="browser" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sentry.AspNetCore" Version="4.13.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="5.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeMirror6\CodeMirror6.csproj" />

--- a/Examples.BlazorServer/Examples.BlazorServer.csproj
+++ b/Examples.BlazorServer/Examples.BlazorServer.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/Examples.BlazorServer/Properties/launchSettings.json
+++ b/Examples.BlazorServer/Properties/launchSettings.json
@@ -11,7 +11,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:5188",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -20,7 +20,7 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "https://localhost:7045;http://localhost:5188",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -28,7 +28,7 @@
     },
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
+++ b/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Sentry.AspNetCore" Version="5.1.1" />

--- a/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
+++ b/Examples.BlazorServerInteractive/Examples.BlazorServerInteractive.csproj
@@ -7,7 +7,7 @@
     <Version>0.9.1</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sentry.AspNetCore" Version="4.13.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="5.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeMirror6\CodeMirror6.csproj" />

--- a/Examples.BlazorServerInteractive/Properties/launchSettings.json
+++ b/Examples.BlazorServerInteractive/Properties/launchSettings.json
@@ -12,7 +12,7 @@
       "http": {
         "commandName": "Project",
         "dotnetRunMessages": true,
-        "launchBrowser": true,
+        "launchBrowser": false,
         "applicationUrl": "http://localhost:5260",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
@@ -21,7 +21,7 @@
       "https": {
         "commandName": "Project",
         "dotnetRunMessages": true,
-        "launchBrowser": true,
+        "launchBrowser": false,
         "applicationUrl": "https://localhost:7258;http://localhost:5260",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
@@ -29,7 +29,7 @@
       },
       "IIS Express": {
         "commandName": "IISExpress",
-        "launchBrowser": true,
+        "launchBrowser": false,
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"
         }

--- a/Examples.BlazorWasm/Examples.BlazorWasm.csproj
+++ b/Examples.BlazorWasm/Examples.BlazorWasm.csproj
@@ -10,8 +10,8 @@
     <SupportedPlatform Include="browser-wasm" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.2" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeMirror6\CodeMirror6.csproj" />

--- a/Examples.BlazorWasm/Examples.BlazorWasm.csproj
+++ b/Examples.BlazorWasm/Examples.BlazorWasm.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser-wasm" />

--- a/Examples.BlazorWasm/Properties/launchSettings.json
+++ b/Examples.BlazorWasm/Properties/launchSettings.json
@@ -11,7 +11,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "http://localhost:5253",
       "environmentVariables": {
@@ -21,7 +21,7 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "https://localhost:7228;http://localhost:5253",
       "environmentVariables": {
@@ -30,7 +30,7 @@
     },
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Examples.Common/Examples.Common.csproj
+++ b/Examples.Common/Examples.Common.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <SupportedPlatform Include="browser" />

--- a/Examples.Common/Examples.Common.csproj
+++ b/Examples.Common/Examples.Common.csproj
@@ -12,8 +12,8 @@
     <SupportedPlatform Include="browser-wasm" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
-    <PackageReference Include="Sentry.Extensions.Logging" Version="4.13.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.2" />
+    <PackageReference Include="Sentry.Extensions.Logging" Version="5.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeMirror6\CodeMirror6.csproj" />

--- a/NEW_CHANGELOG.md
+++ b/NEW_CHANGELOG.md
@@ -1,3 +1,11 @@
+### ⬆️ Upgrade dependencies
+
+- Update nuget packages
+
 ### 🐛 Fix a bug
 
-- Fix CI with dotnet 9
+- Fix logs not in color
+
+### 🗑️ Deprecate code that needs to be cleaned up
+
+- Explicitly loading BlazorCodeMirror6.bundle.scp.css is unneeded and broken (#210)


### PR DESCRIPTION
### ⬆️ Upgrade dependencies

- Update nuget packages

### 🐛 Fix a bug

- Fix logs not in color

### 🗑️ Deprecate code that needs to be cleaned up

- Explicitly loading BlazorCodeMirror6.bundle.scp.css is unneeded and broken (#210)
