### PR TITLE
Added GetCssCompletions parameter to inject additional completions

### DIFF
--- a/CodeMirror6/CodeMirror6Wrapper.razor
+++ b/CodeMirror6/CodeMirror6Wrapper.razor
@@ -13,6 +13,7 @@
             Editable="@Editable"
             FocusChanged="@FocusChanged"
             GetMentionCompletions="@GetMentionCompletions"
+            GetCssCompletions="@GetCssCompletions"
             IndentationUnit="@IndentationUnit"
             Language="@Language"
             LineWrapping="@LineWrapping"

--- a/CodeMirror6/CodeMirror6Wrapper.razor.cs
+++ b/CodeMirror6/CodeMirror6Wrapper.razor.cs
@@ -107,6 +107,12 @@ public partial class CodeMirror6Wrapper : ComponentBase
     /// Get all users available for &#64;user mention completions
     /// </summary>
     [Parameter] public Func<Task<List<CodeMirrorCompletion>>>? GetMentionCompletions { get; set; }
+
+    /// <summary>
+    /// Gets a list of additional variables and class names available for autocomplete in CSS documents.
+    /// </summary>
+    [Parameter] public Func<Task<List<CodeMirrorCompletion>>>? GetCssCompletions { get; set; }
+
     /// <summary>
     /// Upload an IBrowserFile to a server and returns the URL to the file
     /// </summary>

--- a/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
+++ b/CodeMirror6/CodeMirror6WrapperInternal.razor.cs
@@ -111,6 +111,12 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
     /// Get all users available for &#64;user mention completions
     /// </summary>
     [Parameter] public Func<Task<List<CodeMirrorCompletion>>>? GetMentionCompletions { get; set; }
+
+    /// <summary>
+    /// Gets a list of additional variables and class names available for autocomplete in CSS documents.
+    /// </summary>
+    [Parameter] public Func<Task<List<CodeMirrorCompletion>>>? GetCssCompletions { get; set; }
+
     /// <summary>
     /// Upload an IBrowserFile to a server and returns the URL to the file
     /// </summary>
@@ -367,6 +373,14 @@ public partial class CodeMirror6WrapperInternal : ComponentBase, IAsyncDisposabl
                     if (token.IsCancellationRequested) return;
                     if (!await CmJsInterop.PropertySetters.SetMentionCompletions(mentionCompletions)) return;
                 }
+
+                if (GetCssCompletions is not null) {
+                    var cssCompletions = await GetCssCompletions();
+                    if (token.IsCancellationRequested) return;
+                    if (!await CmJsInterop.PropertySetters.SetCssCompletions(cssCompletions)) return;
+                }
+
+
                 if (token.IsCancellationRequested) return;
                 IsCodeMirrorInitialized = true;
                 await InvokeAsync(StateHasChanged);

--- a/CodeMirror6/Commands/CMConfigurationSetters.cs
+++ b/CodeMirror6/Commands/CMConfigurationSetters.cs
@@ -29,6 +29,11 @@ internal class CMSetters(
         mentionCompletions
     );
 
+    internal Task<bool> SetCssCompletions(List<CodeMirrorCompletion> cssCompletions) => cmJsInterop.ModuleInvokeVoidAsync(
+        "setCssCompletions",
+        cssCompletions
+    );
+
     internal Task<bool> ForceRedraw() => cmJsInterop.ModuleInvokeVoidAsync(
         "forceRedraw"
     );

--- a/CodeMirror6/NodeLib/src/CmCssCompletion.ts
+++ b/CodeMirror6/NodeLib/src/CmCssCompletion.ts
@@ -1,0 +1,61 @@
+import { Completion, CompletionContext, CompletionSource, autocompletion } from "@codemirror/autocomplete"
+import { cssCompletionSource } from "@codemirror/lang-css";
+import { syntaxTree } from "@codemirror/language";
+
+let cachedCssVariableCompletions: Completion[] = []
+let cachedCssClassNameCompletions: Completion[] = []
+
+function createCssCompletionsSource(): CompletionSource {
+    return async (context: CompletionContext) => {
+
+
+        let defaultResult = await cssCompletionSource(context);
+        let res;
+        let from;
+        let match;
+
+        var node = syntaxTree(context.state).resolveInner(context.pos, -1);
+        console.log("Node type: ", node.type.name, " at pos: ", context.pos, " from: ", node.from, " to: ", node.to);
+
+        if (node.type.name == "VariableName"  ) {
+            res = cachedCssVariableCompletions;
+            from = node.from; 
+        } else if (node.type.name == "ClassSelector") {
+            res = cachedCssClassNameCompletions;
+            from = context.pos - 1;//node.from;
+        } else if (node.type.name == "ClassName") {
+            res = cachedCssClassNameCompletions;
+            from = node.from-1;
+        }
+        else if (match = context.matchBefore(/(?<=var\(\s*)-(-)?\w*/)) //this one was necessary because it sometimes bugs out and doesn't report VariableName when typing var(-
+        {
+            res = cachedCssVariableCompletions;
+            from = match.from;
+        }
+        else {
+            return defaultResult;
+        }
+
+        if (defaultResult && defaultResult.options) {
+            res = [...res, ...defaultResult.options];
+        }
+
+        return {
+            from: from,
+            to: context.pos,
+            options: res,
+            filter: true,
+            validFor: defaultResult ? defaultResult.validFor : undefined
+        };
+    };
+}
+
+export function setCachedCssCompletions(completions: Completion[]) {
+    cachedCssVariableCompletions = completions.filter(c => c.label.startsWith('--'));
+    cachedCssClassNameCompletions = completions.filter(c => c.label.startsWith('.')); // filter for class names
+}
+
+export const cssCompletionExtension = (enabled: boolean) => {
+    if (!enabled) return []
+    return [createCssCompletionsSource()]
+}

--- a/CodeMirror6/NodeLib/src/index.ts
+++ b/CodeMirror6/NodeLib/src/index.ts
@@ -45,6 +45,7 @@ import { blockquote } from "./CmBlockquote"
 import { listsExtension } from "./CmLists"
 import { dynamicHrExtension } from "./CmHorizontalRule"
 import { mentionCompletionExtension, setCachedCompletions } from "./CmMentionsCompletion"
+import { cssCompletionExtension, setCachedCssCompletions } from "./CmCssCompletion"
 import { mentionDecorationExtension } from "./CmMentionsView"
 import { viewEmojiExtension } from "./CmEmojiView"
 import { emojiCompletionExtension } from "./CmEmojiCompletion"
@@ -199,6 +200,13 @@ export async function initCodeMirror(
             extensions.push(lintGutter())
 
         extensions.push(...getFileUploadExtensions(id, setup))
+
+     
+        if (setup.autocompletion === true && initialConfig.languageName === "CSS") {
+            extensions.push(autocompletion({
+                override: [...cssCompletionExtension(true)]
+            }))
+        }
 
         const pasteHandler = EditorView.domEventHandlers({
             paste(event: ClipboardEvent, view: EditorView) {
@@ -466,6 +474,11 @@ export async function setConfiguration(id: string, newConfig: CmConfiguration) {
 
 export function setMentionCompletions(id: string, mentionCompletions: Completion[]) {
     setCachedCompletions(mentionCompletions)
+    forceRedraw(id)
+}
+
+export function setCssCompletions(id: string, cssCompletions: Completion[]) {
+    setCachedCssCompletions(cssCompletions)
     forceRedraw(id)
 }
 


### PR DESCRIPTION
Helps to add variable names to the autocompletions in CSS when those variables are not part of the document but will be known at runtime. Also possible to suggest class names, which is useful in situations where you have to edit a CSS for a known HTML with known class names.